### PR TITLE
Fix downloading with order for arm data

### DIFF
--- a/doe_dap_dl/dap.py
+++ b/doe_dap_dl/dap.py
@@ -7,7 +7,7 @@ import traceback
 
 from getpass import getpass
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import urlparse, parse_qs
 
 from .utils.scraper import get_api_url
 
@@ -458,8 +458,9 @@ class DAP:
         for url in urls:
             try:
                 parsed_url = urlparse(url)
-                if 'adc.arm.gov' in parsed_url.netloc:
-                    filename = parsed_url.query.split("file=")[1]
+                query = parse_qs(parsed_url.query)
+                if 'file' in query:
+                    filename = query['file'][0]
                 else:
                     filename = parsed_url.path.split("/")[-1]
 

--- a/doe_dap_dl/dap.py
+++ b/doe_dap_dl/dap.py
@@ -456,8 +456,10 @@ class DAP:
         # TODO: multi-thread this
         for url in urls:
             try:
-                a = url.split("/")
-                filename = a[5].split("?")[0]
+                if 'adc.arm.gov' in url:
+                    filename = url.split("file=")[1]
+                else:
+                    filename = url.split("/")[5].split("?")[0]
 
                 download_dir = path
                 os.makedirs(download_dir, exist_ok=True)

--- a/doe_dap_dl/dap.py
+++ b/doe_dap_dl/dap.py
@@ -7,6 +7,7 @@ import traceback
 
 from getpass import getpass
 from pathlib import Path
+from urllib.parse import urlparse
 
 from .utils.scraper import get_api_url
 
@@ -456,10 +457,11 @@ class DAP:
         # TODO: multi-thread this
         for url in urls:
             try:
-                if 'adc.arm.gov' in url:
-                    filename = url.split("file=")[1]
+                parsed_url = urlparse(url)
+                if 'adc.arm.gov' in parsed_url.netloc:
+                    filename = parsed_url.query.split("file=")[1]
                 else:
-                    filename = url.split("/")[5].split("?")[0]
+                    filename = parsed_url.path.split("/")[-1]
 
                 download_dir = path
                 os.makedirs(download_dir, exist_ok=True)


### PR DESCRIPTION
Download URLs for ARM data have a different format than other datasets. Now we check the format before trying to extract the filename.