### PR TITLE
Remove reading from requirements.txt in setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-requests
-matplotlib
-numpy
-netcdf4

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 import setuptools
 

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,9 @@
 import os
-import pathlib
+from pathlib import Path
 import setuptools
 
-# The directory containing this file
-CWD = pathlib.Path(__file__).parent
-
 # The text of the README file
-README = (CWD / "README.md").read_text()
-
-# Get the list of dependencies from the requirements.txt file
-with open(os.path.join(CWD, "requirements.txt")) as requirements_file:
-    # Parse requirements.txt, ignoring any commented-out lines.
-    REQUIREMENTS = [
-        line for line in requirements_file.read().splitlines() if not line.startswith("#")
-    ]
+README = Path("README.md").read_text()
 
 version = "0.1.0"
 assert "." in version
@@ -42,6 +32,11 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=["docs", "tests", "examples"]),
     include_package_data=True,
     zip_safe=False,
-    install_requires=REQUIREMENTS,
+    install_requires=[
+        "requests",
+        "matplotlib",
+        "numpy",
+        "netcdf4"
+    ],
     scripts=[],
 )


### PR DESCRIPTION
This PR fixes this error that users get when installing doe-dap-dl with pip

```
$ pip install doe-dap-dl
Collecting doe-dap-dl
  Using cached doe-dap-dl-0.1.0-9.tar.gz (12 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [10 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "C:\Users\kieb843\AppData\Local\Temp\pip-install-5lytmana\doe-dap-dl_476dbc283e084740b6cf34ce6cebfcaf\setup.py", line 8, in <module>
          req_strings = Path("requirements.txt").read_text().strip().splitlines()
        File "C:\Users\kieb843\AppData\Local\Programs\Python\Python310\lib\pathlib.py", line 1134, in read_text
          with self.open(mode='r', encoding=encoding, errors=errors) as f:
        File "C:\Users\kieb843\AppData\Local\Programs\Python\Python310\lib\pathlib.py", line 1119, in open
          return self._accessor.open(self, mode, buffering, encoding, errors,
      FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

My solution is to simply not read the required packages from requirements.txt.