### PR TITLE
Fix sending 'successfully set up authentication' message when setting up 2fa fails

### DIFF
--- a/doe_dap_dl/dap.py
+++ b/doe_dap_dl/dap.py
@@ -248,7 +248,9 @@ class DAP:
             f"Setting up two-factor authentication for user {params['username']}..."
         )
 
-        self.__request_cert_auth(params)
+        if not self.__request_cert_auth(params):
+            self.__print(f"Setting up two-factor authentication failed.")
+            return False
 
         valid = self.__cert_is_valid()
         if valid:


### PR DESCRIPTION
Previously the return value of `__request_cert_auth()` was not checked when setting up two factor authentication. Sometimes this could result in the success message of 'Successfully set up two-factor authentication for user...' despite the request for a certificate failing. Now the result of `__request_cert_auth()` is checked when setting up 2fa, and we exit from `setup_two_factor_auth()` if requesting a certificate failed.