### PR TITLE
Improve post-download summary

### DIFF
--- a/doe_dap_dl/dap.py
+++ b/doe_dap_dl/dap.py
@@ -452,8 +452,11 @@ class DAP:
         if not urls:
             raise Exception("No urls provided")
 
-        downloaded_files = []
+        downloaded_paths = []
         self.__print(f"Attempting to download {len(urls)} files...")
+        downloaded = 0
+        failed = 0
+        skipped = 0
         # TODO: multi-thread this
         for url in urls:
             try:
@@ -469,24 +472,27 @@ class DAP:
                 # the final file path
                 filepath = os.path.join(download_dir, filename)
             except:
-                self.__print(f"Incorrectly formmated file path in url: {url}")
+                self.__print(f"Incorrectly formatted file path in url: {url}")
+                failed += 1
                 continue
 
             if not replace and os.path.exists(filepath):
                 self.__print(f"File: {filepath} already exists, skipping...")
+                skipped += 1
             else:
                 try:
                     self.__download(url, filepath)
+                    downloaded_paths.append(filepath)
+                    downloaded += 1
                 except BadStatusCodeError as e:
                     self.__print(f"Could not download file: {filepath}")
                     self.__print(e)
+                    failed += 1
                     continue
 
-            downloaded_files.append(filepath)
+        self.__print(f"{downloaded} files downloaded, {failed} failed, {skipped} skipped")
 
-        self.__print(f"Downloaded {len(downloaded_files)} files!")
-
-        return downloaded_files
+        return downloaded_paths
 
     # --------------------------------------------------------------
     # Place Order and Download


### PR DESCRIPTION
This PR improves the summary doe-dap-dl prints after downloading files. Previously it had simply reported the number of files that were either downloaded or already existed on the user's machine. It also didn't mention how many files had failed to download. 

Now the number of files that successfully downloaded, already existed and were skipped, and failed to download are reported.