### PR TITLE
Fixed an issue where downloading larger files is slow

### DIFF
--- a/doe_dap_dl/dap.py
+++ b/doe_dap_dl/dap.py
@@ -116,11 +116,11 @@ class DAP:
     # Getting Authenticated
     # --------------------------------------------------------------
 
-    def __validate_response(self, response, binary_response=False):
+    def __validate_response(self, response, download_response=False):
         if response.status_code != 200:
             raise BadStatusCodeError(response)
 
-        if binary_response:
+        if download_response:
             return True
 
         text = response.text
@@ -448,7 +448,7 @@ class DAP:
         """Actually download the files"""
         response = requests.get(url, stream=True)
 
-        if not self.__validate_response(response, binary_response=True):
+        if not self.__validate_response(response, download_response=True):
             return
 
         while True:  # is this needed?

--- a/doe_dap_dl/dap.py
+++ b/doe_dap_dl/dap.py
@@ -116,9 +116,12 @@ class DAP:
     # Getting Authenticated
     # --------------------------------------------------------------
 
-    def __validate_response(self, response):
+    def __validate_response(self, response, binary_response=False):
         if response.status_code != 200:
             raise BadStatusCodeError(response)
+
+        if binary_response:
+            return True
 
         text = response.text
         if "errorMessage" in text:
@@ -445,7 +448,7 @@ class DAP:
         """Actually download the files"""
         response = requests.get(url, stream=True)
 
-        if not self.__validate_response(response):
+        if not self.__validate_response(response, binary_response=True):
             return
 
         while True:  # is this needed?


### PR DESCRIPTION
When a response to download a large (on the order of megabytes) is made, grabbing the `text` from this request takes a long time. So we no longer grab the `text` from the response when downloading files.